### PR TITLE
Correct line 278

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@ function generateOutput() {
     // remember to %-encode the element string before passing to DL Toolkit (not sure this is still necessary 2021-07-12)
 
     let res = getResolver();
-    res = res.substring(0,res.length-1);
+    res=res.replace(/\/$/,"");
     let compDL = gs1dlt.compressGS1DigitalLink(dlURI, false, res, false, true, false);
     console.log(`Compressed URL is ${compDL}`);
 


### PR DESCRIPTION
Line 278 previously unhelpfully deleted the final character from the user-defined resolver string without even checking whether it was a trailing forward-slash or not - resulting in https://id.gs1.ch being idiotically truncated to https://id/gs1.c

The replacement line 278 now only removes a single forward-clash character if it appears at the end of the user-defined resolver URL stem.  Otherwise no change is made.